### PR TITLE
Added plugin for documentation generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -240,6 +240,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@godaddy/dmd": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@godaddy/dmd/-/dmd-1.0.3.tgz",
+      "integrity": "sha512-KYHGKLYG34Ni8a3zf3YQ+hOed5pc+Mg6dboh1XOAQiX9lZARY8ZiO4F7xsX/vk3ozAu/JkjDJw+AUt5ar9divg=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.2.5",
+    "@godaddy/dmd": "^1.0.3",
     "jsdoc-to-markdown": "^6.0.1",
     "markdown-table": "^2.0.0",
     "markshell": "0.0.9",

--- a/src/helpers/package/get-main.js
+++ b/src/helpers/package/get-main.js
@@ -19,7 +19,8 @@ function genBaseDocs () {
     files: '**/**.js',
     'example-lang': 'js',
     'no-cache': true,
-    'heading-depth': 2
+    'heading-depth': 2,
+    plugin: '@godaddy/dmd'
   }
   return jsdoc2md.renderSync(opts).trim()
 }

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -9,6 +9,7 @@ describe('template-action', function () {
   require('./pre/tests.js')
   // *******
   it('should error when using a non supported repository type', async function () {
+    this.timeout(30000)
     process.env.INPUT_TYPE = 'hello'
     await runAction(['main'])
     existsSync('test/README.md').should.equal(false)

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -1,10 +1,18 @@
 /* eslint-env mocha */
+const runAction = require('./helpers/run-action.js')
+const { existsSync } = require('fs')
+const chai = require('chai')
+chai.should()
 
 describe('template-action', function () {
   // ******* DO NOT REMOVE THIS TEST!
   require('./pre/tests.js')
   // *******
-
+  it('should error when using a non supported repository type', async function () {
+    process.env.INPUT_TYPE = 'hello'
+    await runAction(['main'])
+    existsSync('test/README.md').should.equal(false)
+  })
   require('./action/tests.js')
   require('./package/tests.js')
 })

--- a/test/package/cli-pkg/validation.md
+++ b/test/package/cli-pkg/validation.md
@@ -6,14 +6,15 @@ npm i -g test-repo
 
 # Usage
 
-<a name="protection"></a>
+## protection(cloak, dagger)
 
-## protection(cloak, dagger) ⇒ <code>survival</code>
 A quite wonderful function.
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| cloak | <code>object</code> | Privacy gown |
-| dagger | <code>object</code> | Security |
+| cloak | `object` | Privacy gown |
+| dagger | `object` | Security |
+
+<!-- LINKS -->

--- a/test/package/nested/validation.md
+++ b/test/package/nested/validation.md
@@ -8,35 +8,36 @@ npm i test-repo
 
 ## Functions
 
-<dl>
-<dt><a href="#protection">protection(cloak, dagger)</a> ⇒ <code>survival</code></dt>
-<dd><p>A quite wonderful function.</p>
-</dd>
-<dt><a href="#help">help(message, destination)</a> ⇒ <code>call</code></dt>
-<dd><p>A function to call for help.</p>
-</dd>
-</dl>
+Name | Description
+------ | -----------
+[protection(cloak, dagger)] | A quite wonderful function.
+[help(message, destination)] | A function to call for help.
 
-<a name="protection"></a>
 
-## protection(cloak, dagger) ⇒ <code>survival</code>
+## protection(cloak, dagger)
+
 A quite wonderful function.
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| cloak | <code>object</code> | Privacy gown |
-| dagger | <code>object</code> | Security |
+| cloak | `object` | Privacy gown |
+| dagger | `object` | Security |
 
-<a name="help"></a>
 
-## help(message, destination) ⇒ <code>call</code>
+## help(message, destination)
+
 A function to call for help.
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| message | <code>string</code> | Message to send |
-| destination | <code>object</code> | Destination for message |
+| message | `string` | Message to send |
+| destination | `object` | Destination for message |
+
+<!-- LINKS -->
+
+[protection(cloak, dagger)]:#protectioncloak-dagger
+[help(message, destination)]:#helpmessage-destination

--- a/test/package/no-template/validation.md
+++ b/test/package/no-template/validation.md
@@ -6,14 +6,15 @@ npm i test-repo
 
 # Usage
 
-<a name="protection"></a>
+## protection(cloak, dagger)
 
-## protection(cloak, dagger) ⇒ <code>survival</code>
 A quite wonderful function.
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| cloak | <code>object</code> | Privacy gown |
-| dagger | <code>object</code> | Security |
+| cloak | `object` | Privacy gown |
+| dagger | `object` | Security |
+
+<!-- LINKS -->

--- a/test/package/with-template/validation.md
+++ b/test/package/with-template/validation.md
@@ -10,16 +10,17 @@ npm i test-repo
 
 # Usage
 
-<a name="protection"></a>
+## protection(cloak, dagger)
 
-## protection(cloak, dagger) ⇒ <code>survival</code>
 A quite wonderful function.
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| cloak | <code>object</code> | Privacy gown |
-| dagger | <code>object</code> | Security |
+| cloak | `object` | Privacy gown |
+| dagger | `object` | Security |
+
+<!-- LINKS -->
 
 End of the test

--- a/test/package/wrong-template/validation.md
+++ b/test/package/wrong-template/validation.md
@@ -6,14 +6,15 @@ npm i test-repo
 
 # Usage
 
-<a name="protection"></a>
+## protection(cloak, dagger)
 
-## protection(cloak, dagger) ⇒ <code>survival</code>
 A quite wonderful function.
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| cloak | <code>object</code> | Privacy gown |
-| dagger | <code>object</code> | Security |
+| cloak | `object` | Privacy gown |
+| dagger | `object` | Security |
+
+<!-- LINKS -->


### PR DESCRIPTION
**Changes description**
Added `@godaddy/dmd` as plugin for generating documentation for packages. This gives a cleaner output in markdown, removing a bit of the clutter produces by default by `jsdoc-to-markdown`.

**New features**
- _tests:_ now testing that the action exits when provided an invalid `type` input

**Updated features**
- _`package` docs generator:_ now uses `@godaddy/dmd` as plugin to format/cleanup the output produced by `jsdoc-to-markdown`
- _tests:_ updated tests accordingly