### PR TITLE
Added indentation in examples sections

### DIFF
--- a/src/main-handlers/api/build-examples.js
+++ b/src/main-handlers/api/build-examples.js
@@ -47,8 +47,9 @@ function mapToString (obj = {}, sep, col) {
   return Object.entries(obj).map(entry => entry[0] + sep + entry[1]).join(col)
 }
 
-function formatNamedData (heading, data) {
-  return data && String(data).length > 0
+function formatNamedData (heading, data = '') {
+  data = String(data)
+  return data.length > 0
     ? `${heading}:\n${data.split('\n').map(line => '\t' + line).join('\n')}`
     : ''
 }

--- a/src/main-handlers/api/build-examples.js
+++ b/src/main-handlers/api/build-examples.js
@@ -48,7 +48,9 @@ function mapToString (obj = {}, sep, col) {
 }
 
 function formatNamedData (heading, data) {
-  return data && String(data).length > 0 ? `${heading}:\n${data}` : ''
+  return data && String(data).length > 0
+    ? `${heading}:\n${data.split('\n').map(line => '\t' + line).join('\n')}`
+    : ''
 }
 
 function formatBlock (type, block) {

--- a/src/main-handlers/api/build-examples.js
+++ b/src/main-handlers/api/build-examples.js
@@ -50,7 +50,7 @@ function mapToString (obj = {}, sep, col) {
 function formatNamedData (heading, data = '') {
   data = String(data)
   return data.length > 0
-    ? `${heading}:\n${data.split('\n').map(line => '\t' + line).join('\n')}`
+    ? `${heading}:\n${data.split('\n').map(line => '  ' + line).join('\n')}`
     : ''
 }
 

--- a/test/api/authorizer/IAM-object/validation.md
+++ b/test/api/authorizer/IAM-object/validation.md
@@ -49,29 +49,29 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
+  Content-Type: application/json
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/authorizer/IAM-string/validation.md
+++ b/test/api/authorizer/IAM-string/validation.md
@@ -49,29 +49,29 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
+  Content-Type: application/json
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/authorizer/cognito-arn/validation.md
+++ b/test/api/authorizer/cognito-arn/validation.md
@@ -47,30 +47,30 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
-Authorization: Bearer COGNITO_ACCESS_TOKEN
+  Content-Type: application/json
+  Authorization: Bearer COGNITO_ACCESS_TOKEN
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/authorizer/cognito/validation.md
+++ b/test/api/authorizer/cognito/validation.md
@@ -47,30 +47,30 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
-Authorization: Bearer COGNITO_ACCESS_TOKEN
+  Content-Type: application/json
+  Authorization: Bearer COGNITO_ACCESS_TOKEN
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/authorizer/custom-object/validation.md
+++ b/test/api/authorizer/custom-object/validation.md
@@ -47,30 +47,30 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
-Authorization: AUTHORIZATION_VALUE
+  Content-Type: application/json
+  Authorization: AUTHORIZATION_VALUE
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/authorizer/custom-string/validation.md
+++ b/test/api/authorizer/custom-string/validation.md
@@ -47,30 +47,30 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
-Authorization: AUTHORIZATION_VALUE
+  Content-Type: application/json
+  Authorization: AUTHORIZATION_VALUE
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/authorizer/identity-validation/validation.md
+++ b/test/api/authorizer/identity-validation/validation.md
@@ -47,30 +47,30 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
-Authorization: AUTHORIZATION_VALUE
+  Content-Type: application/json
+  Authorization: AUTHORIZATION_VALUE
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/authorizer/lambda-arn/validation.md
+++ b/test/api/authorizer/lambda-arn/validation.md
@@ -47,30 +47,30 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
-Authorization: AUTHORIZATION_VALUE
+  Content-Type: application/json
+  Authorization: AUTHORIZATION_VALUE
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/authorizer/lambda-request/validation.md
+++ b/test/api/authorizer/lambda-request/validation.md
@@ -47,30 +47,30 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
-Authorization: AUTHORIZATION_VALUE
+  Content-Type: application/json
+  Authorization: AUTHORIZATION_VALUE
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/authorizer/lambda-token/validation.md
+++ b/test/api/authorizer/lambda-token/validation.md
@@ -47,30 +47,30 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
-Authorization: AUTHORIZATION_VALUE
+  Content-Type: application/json
+  Authorization: AUTHORIZATION_VALUE
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/authorizer/multi-identity-sources/validation.md
+++ b/test/api/authorizer/multi-identity-sources/validation.md
@@ -47,31 +47,31 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test&token=TOKEN_VALUE
 
 Headers:
-Content-Type: application/json
-Authorization: AUTHORIZATION_VALUE
-some-header: SOME-HEADER_VALUE
+  Content-Type: application/json
+  Authorization: AUTHORIZATION_VALUE
+  some-header: SOME-HEADER_VALUE
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/base-url/no-hostname/validation.md
+++ b/test/api/base-url/no-hostname/validation.md
@@ -45,29 +45,29 @@ _Request:_
 GET https://API_DOMAIN/logical-unit/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
+  Content-Type: application/json
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/base-url/no-root/validation.md
+++ b/test/api/base-url/no-root/validation.md
@@ -45,29 +45,29 @@ _Request:_
 GET https://example.com/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
+  Content-Type: application/json
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/base-url/regular/validation.md
+++ b/test/api/base-url/regular/validation.md
@@ -45,29 +45,29 @@ _Request:_
 GET https://example.com/logical-unit/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
+  Content-Type: application/json
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/examples/multi-example/validation.md
+++ b/test/api/examples/multi-example/validation.md
@@ -45,29 +45,29 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
+  Content-Type: application/json
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 
@@ -80,29 +80,29 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
+  Content-Type: application/json
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/examples/no-qs/validation.md
+++ b/test/api/examples/no-qs/validation.md
@@ -45,13 +45,13 @@ _Request:_
 GET https://API_DOMAIN/hello
 
 Headers:
-Content-Type: application/json
+  Content-Type: application/json
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 </details>
 

--- a/test/api/examples/no-request-body/validation.md
+++ b/test/api/examples/no-request-body/validation.md
@@ -45,7 +45,7 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
+  Content-Type: application/json
 ```
 </details>
 

--- a/test/api/examples/no-request-headers/validation.md
+++ b/test/api/examples/no-request-headers/validation.md
@@ -45,10 +45,10 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 </details>
 

--- a/test/api/examples/no-request/validation.md
+++ b/test/api/examples/no-request/validation.md
@@ -43,16 +43,16 @@ _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/examples/no-response-body/validation.md
+++ b/test/api/examples/no-response-body/validation.md
@@ -43,10 +43,10 @@ _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 ```
 </details>
 

--- a/test/api/examples/no-response-headers/validation.md
+++ b/test/api/examples/no-response-headers/validation.md
@@ -43,13 +43,13 @@ _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/examples/no-response/validation.md
+++ b/test/api/examples/no-response/validation.md
@@ -45,13 +45,13 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
+  Content-Type: application/json
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 </details>
 

--- a/test/api/examples/no-status-code/validation.md
+++ b/test/api/examples/no-status-code/validation.md
@@ -43,13 +43,13 @@ _Response:_
 
 ```HTTP
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/examples/single-example/validation.md
+++ b/test/api/examples/single-example/validation.md
@@ -45,29 +45,29 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
+  Content-Type: application/json
 
 Body:
-{
-  "param1": "does not make sense in GET",
-  "param2": "but this is a test"
-}
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
 ```
 
 _Response:_
 
 ```HTTP
 Status code:
-200
+  200
 
 Headers:
-x-kaskadi-data: some data
+  x-kaskadi-data: some data
 
 Body:
-{
-  "resParam1": "hello",
-  "resParam2": "test"
-}
+  {
+    "resParam1": "hello",
+    "resParam2": "test"
+  }
 ```
 </details>
 

--- a/test/api/examples/text-body/validation.md
+++ b/test/api/examples/text-body/validation.md
@@ -45,10 +45,10 @@ _Request:_
 GET https://API_DOMAIN/hello?key1=hello&key2=test
 
 Headers:
-Content-Type: application/json
+  Content-Type: application/json
 
 Body:
-this is a body
+  this is a body
 ```
 </details>
 


### PR DESCRIPTION
**Changes description**
Added indentation for `body`, `headers` and `status code` sections in request/response examples.

**New features**
- _indentation in examples:_ sections now have indentation in their body to improve readability

**Updated features**
- _tests:_ updated tests accordingly