### PR TITLE
Improved layer dependencies retrieval

### DIFF
--- a/test/layer/local-utils/layer/nodejs/package.json
+++ b/test/layer/local-utils/layer/nodejs/package.json
@@ -15,7 +15,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.1"
+  },
+  "devDependencies": {
     "yaml": "^1.10.0"
   }
 }

--- a/test/layer/local-utils/validation.md
+++ b/test/layer/local-utils/validation.md
@@ -12,7 +12,6 @@ This is a template layer
 ### Dependencies
 
 - `node-fetch`, version: `2.6.1` ([see on NPM](https://www.npmjs.com/package/node-fetch))
-- `yaml`, version: `1.10.0` ([see on NPM](https://www.npmjs.com/package/yaml))
 - `foo` (local utility)
 
 See [configuration file](./serverless.yml) for more details.


### PR DESCRIPTION
**Changes description**
Added filtering for dev dependencies when retrieving local utilities in layers.

**New features**
- _layer dependencies retrieval:_ we now also analyze and filter out dev dependencies when retrieving local utilities in layer

**Updated features**
- _tests:_ moved `yaml` to devDependencies in related test to test new feature + updated validation file accordingly