### PR TITLE
Implemented path parameters replacement

### DIFF
--- a/src/main-handlers/api/build-examples.js
+++ b/src/main-handlers/api/build-examples.js
@@ -39,6 +39,14 @@ function addAuthorizerData (request, authorizerData) {
 }
 
 // helpers for building example request and response
+function replacePathParams (path, pathParams = {}) {
+  return Object.entries(pathParams)
+    .reduce((acc, entry) => {
+      const regExp = new RegExp(`{${entry[0]}}`, 'g')
+      return acc.replace(regExp, entry[1])
+    }, path)
+}
+
 function getBody (body = '') {
   return typeof body === 'string' ? body : JSON.stringify(body, null, 2)
 }
@@ -69,7 +77,7 @@ function buildExampleRequest (method, endpoint, request) {
   const { body, queryStringParameters, headers } = request
   let qs = mapToString(queryStringParameters, '=', '&')
   qs = qs.length > 0 ? `?${qs}` : qs
-  const exampleReq = `${method.method} ${method['base-url']}${endpoint.path}${qs}\n\n${formatNamedData('Headers', mapToString(headers, ': ', '\n'))}\n\n${formatNamedData('Body', getBody(body))}`
+  const exampleReq = `${method.method} ${method['base-url']}${replacePathParams(endpoint.path, endpoint.pathParameters)}${qs}\n\n${formatNamedData('Headers', mapToString(headers, ': ', '\n'))}\n\n${formatNamedData('Body', getBody(body))}`
   return formatExample(formatBlock('Request', exampleReq), request.heading)
 }
 

--- a/src/main-handlers/api/build-examples.js
+++ b/src/main-handlers/api/build-examples.js
@@ -42,7 +42,7 @@ function addAuthorizerData (request, authorizerData) {
 function replacePathParams (path, pathParams = {}) {
   return Object.entries(pathParams)
     .reduce((reducedPath, entry) => {
-      const regExp = new RegExp(`{${entry[0]}}`, 'g')
+      const regExp = new RegExp(`{${entry[0].replace('+', '\\+')}}`, 'g')
       return reducedPath.replace(regExp, entry[1])
     }, path)
 }

--- a/src/main-handlers/api/build-examples.js
+++ b/src/main-handlers/api/build-examples.js
@@ -42,7 +42,8 @@ function addAuthorizerData (request, authorizerData) {
 function replacePathParams (path, pathParams = {}) {
   return Object.entries(pathParams)
     .reduce((reducedPath, entry) => {
-      const regExp = new RegExp(`{${entry[0].replace('+', '\\+')}}`, 'g')
+      const param = entry[0].replace(/\+/g, '\\+')
+      const regExp = new RegExp(`{${param}}`, 'g')
       return reducedPath.replace(regExp, entry[1])
     }, path)
 }

--- a/src/main-handlers/api/build-examples.js
+++ b/src/main-handlers/api/build-examples.js
@@ -42,7 +42,7 @@ function addAuthorizerData (request, authorizerData) {
 function replacePathParams (path, pathParams = {}) {
   return Object.entries(pathParams)
     .reduce((reducedPath, entry) => {
-      const param = entry[0].replace(/\+/g, '\\+')
+      const param = entry[0].replace(/[+]/g, '\\+')
       const regExp = new RegExp(`{${param}}`, 'g')
       return reducedPath.replace(regExp, entry[1])
     }, path)

--- a/src/main-handlers/api/build-examples.js
+++ b/src/main-handlers/api/build-examples.js
@@ -41,9 +41,9 @@ function addAuthorizerData (request, authorizerData) {
 // helpers for building example request and response
 function replacePathParams (path, pathParams = {}) {
   return Object.entries(pathParams)
-    .reduce((acc, entry) => {
+    .reduce((reducedPath, entry) => {
       const regExp = new RegExp(`{${entry[0]}}`, 'g')
-      return acc.replace(regExp, entry[1])
+      return reducedPath.replace(regExp, entry[1])
     }, path)
 }
 
@@ -74,10 +74,10 @@ function buildExampleRequest (method, endpoint, request) {
   if (!request) {
     return ''
   }
-  const { body, queryStringParameters, headers } = request
+  const { body, queryStringParameters, pathParameters, headers } = request
   let qs = mapToString(queryStringParameters, '=', '&')
   qs = qs.length > 0 ? `?${qs}` : qs
-  const exampleReq = `${method.method} ${method['base-url']}${replacePathParams(endpoint.path, endpoint.pathParameters)}${qs}\n\n${formatNamedData('Headers', mapToString(headers, ': ', '\n'))}\n\n${formatNamedData('Body', getBody(body))}`
+  const exampleReq = `${method.method} ${method['base-url']}${replacePathParams(endpoint.path, pathParameters)}${qs}\n\n${formatNamedData('Headers', mapToString(headers, ': ', '\n'))}\n\n${formatNamedData('Body', getBody(body))}`
   return formatExample(formatBlock('Request', exampleReq), request.heading)
 }
 

--- a/test/api/examples/path-params/lambdas/hello-world/index.js
+++ b/test/api/examples/path-params/lambdas/hello-world/index.js
@@ -1,0 +1,11 @@
+module.exports.handler = async (event) => {
+  return {
+    statusCode: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*'
+    },
+    body: JSON.stringify({
+      message: 'Hello World!'
+    })
+  }
+}

--- a/test/api/examples/path-params/lambdas/hello-world/package.json
+++ b/test/api/examples/path-params/lambdas/hello-world/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hello-world",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Klimapartner GmbH <kontakt@klimapartner.de> (https://klimapartner.de)",
+  "contributors": [
+    "Holger Will <h.will@klimapartner.de>",
+    "Alexis Lemaire <a.lemaire@klimapartner.de>"
+  ],
+  "license": "MIT"
+}

--- a/test/api/examples/path-params/lambdas/hello-world/serverless.yml
+++ b/test/api/examples/path-params/lambdas/hello-world/serverless.yml
@@ -1,0 +1,42 @@
+handler: lambdas/hello-world/index.handler
+name: hello-world
+package:
+  include:
+    - lambdas/hello-world/index.js
+    - lambdas/hello-world/node_modules/**
+events:
+  - http:
+      method: get
+      path: hello/{id}/{some-param}/{another_param}/{proxy+}
+      cors: true
+      kaskadi-docs:
+        description: placeholder endpoint
+        queryStringParameters:
+          - key: key1
+            description: first key
+          - key: key2
+            description: second key
+            default: 35 
+        # doesn't make sense with GET but that's just for testing here
+        body:
+          - key: param1
+            description: first body param
+            default: 'hello'
+          - key: param2
+            description: second body param
+            default: true
+        examples:
+          - request:
+              pathParameters:
+                id: 123
+                some-param: true
+                another_param: hey
+                proxy+: hello
+              queryStringParameters:
+                key1: hello
+                key2: test
+              body:
+                param1: does not make sense in GET
+                param2: but this is a test
+              headers:
+                'Content-Type': 'application/json'

--- a/test/api/examples/path-params/package.json
+++ b/test/api/examples/path-params/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "template-kaskadi-api",
+  "version": "1.0.0",
+  "description": "",
+  "main": "serverless.yml",
+  "scripts": {
+    "test": "echo \"No test script defined.\"",
+    "coverage": "echo \"No coverage script defined.\"",
+    "lint": "standard --fix",
+    "preinstall": "./tools/install.sh",
+    "dev": "export NODE_PATH=./layer/nodejs/node_modules && sls offline",
+    "add-lambda": "node ./tools/add-lambda/add-lambda.js",
+    "update-version": "node ./tools/update-version/update-version.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaskadi/template-kaskadi-api.git"
+  },
+  "keywords": [],
+  "author": "Klimapartner GmbH <kontakt@klimapartner.de> (https://klimapartner.de)",
+  "contributors": [
+    "Holger Will <h.will@klimapartner.de>",
+    "Alexis Lemaire <a.lemaire@klimapartner.de>"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kaskadi/template-kaskadi-api/issues"
+  },
+  "homepage": "https://github.com/kaskadi/template-kaskadi-api#readme",
+  "devDependencies": {
+    "serverless-offline": "^6.4.0"
+  },
+  "dependencies": {
+    "serverless-aws-documentation": "^1.1.0"
+  }
+}

--- a/test/api/examples/path-params/serverless.yml
+++ b/test/api/examples/path-params/serverless.yml
@@ -1,0 +1,34 @@
+service:
+  name: template-kaskadi-api
+package:
+  individually: true
+  exclude:
+    - '**/**'
+plugins:
+  - serverless-aws-documentation
+  - serverless-offline
+custom:
+  documentation:
+    api:
+      info:
+        version: 1.0.0
+        title: ${self:service.name}
+        description: Template API
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stackName: ${self:service.name}-stack
+  apiName: ${self:service.name}
+  stage: ${opt:stage, 'prod'}
+  region: eu-central-1
+  deploymentBucket:
+    name: kaskadi-serverless-deployment-bucket
+  stackTags:
+    app: your-app-name
+  tags:
+    app: your-app-name
+    service: ${self:service.name}
+    logical-unit: api-logical-unit
+    type: s3, sns, etc.
+functions:
+  HelloWorld: ${file(./lambdas/hello-world/serverless.yml)}

--- a/test/api/examples/path-params/tools/install.sh
+++ b/test/api/examples/path-params/tools/install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ -d "layer" ] && [ -f "layer/nodejs/package.json" ]
+  then
+    cd layer/nodejs || exit
+    npm i
+    cd ../../
+fi

--- a/test/api/examples/path-params/validation.md
+++ b/test/api/examples/path-params/validation.md
@@ -1,0 +1,83 @@
+# API endpoints
+
+The origin and root path for this API is: `https://API_DOMAIN`
+
+The following endpoints are defined in this API:
+- [/hello/{id}/{some-param}/{another_param}/{proxy+}](#/hello/{id}/{some-param}/{another_param}/{proxy+})
+
+## `/hello/{id}/{some-param}/{another_param}/{proxy+}` <a name="/hello/{id}/{some-param}/{another_param}/{proxy+}"></a>
+
+Supported methods:
+- [GET](#hello/{id}/{some-param}/{another_param}/{proxy+}-GET)
+
+### `GET` (target lambda → [hello-world](#hello-world)) <a name="hello/{id}/{some-param}/{another_param}/{proxy+}-GET"></a>
+
+**Description:**
+
+placeholder endpoint
+
+**Authorization:**
+
+No authorizer found for this method.
+
+**Query string parameters:**
+
+|   Key  | Default | Description |
+| :----: | :-----: | :---------- |
+| `key1` |         | first key   |
+| `key2` |   `35`  | second key  |
+
+**Request body:**
+
+|    Key   | Default | Description       |
+| :------: | :-----: | :---------------- |
+| `param1` | `hello` | first body param  |
+| `param2` |  `true` | second body param |
+
+**Examples:**
+
+<details>
+<summary>Example #1</summary>
+
+_Request:_
+
+```HTTP
+GET https://API_DOMAIN/hello/123/true/hey/hello?key1=hello&key2=test
+
+Headers:
+  Content-Type: application/json
+
+Body:
+  {
+    "param1": "does not make sense in GET",
+    "param2": "but this is a test"
+  }
+```
+</details>
+
+# API resources
+
+The following lambda functions are used in this API:
+- [hello-world](#hello-world)
+
+The following layers are used in this API:
+_no layer defined in the [configuration file](./serverless.yml)._
+
+## hello-world <a name="hello-world"></a>
+
+|     Name    | Sources                | Timeout |                  Handler                  |
+| :---------: | :--------------------- | :-----: | :---------------------------------------: |
+| hello-world | <ul><li>HTTP</li></ul> | default | [handler](./lambdas/hello-world/index.js) |
+
+See [configuration file](./serverless.yml) for more details.
+
+# Stack tags
+
+You can use any tags (and their respective values) visible below to find ressources related to this stack on AWS. See [here](https://docs.amazonaws.cn/en_us/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html) for more details.
+
+| Tag          | Value                |
+| :----------- | :------------------- |
+| app          | your-app-name        |
+| service      | template-kaskadi-api |
+| logical-unit | api-logical-unit     |
+| type         | s3, sns, etc.        |

--- a/test/api/tests.js
+++ b/test/api/tests.js
@@ -99,6 +99,9 @@ describe('api docs generation', function () {
     it('should generate docs with a text body', async () => {
       await test(cwd, 'test/api/examples/text-body', 'validation.md')
     })
+    it('should generate docs with URL path parameters provided', async () => {
+      await test(cwd, 'test/api/examples/path-params', 'validation.md')
+    })
     it('should generate docs with a given example', async () => {
       await test(cwd, 'test/api/examples/single-example', 'validation.md')
     })


### PR DESCRIPTION
**Changes description**
Implemented path parameters replacement in example request to improve documentation understanding.

**New features**
- _path parameters replacement:_ using the field `request.pathParameters` inside of `kaskadi-docs.examples` for an endpoint, we are able to swap all path parameters for a given value. This improves the user understanding of the documentation.

**Updated features**
- _tests:_ updated tests to reflect new feature