### PR TITLE
Updated element documentation generation logic

### DIFF
--- a/src/helpers/jsdoc-utils/get-data.js
+++ b/src/helpers/jsdoc-utils/get-data.js
@@ -1,9 +1,9 @@
 const { spawnSync } = require('child_process')
 
-module.exports = ({ glob, jsdoc2md }) => {
+module.exports = ({ glob, jsdoc2md }, type) => {
   const opts = {
     files: glob.sync('**/*.js', { ignore: 'node_modules/**' }),
-    'example-lang': 'js',
+    'example-lang': type === 'package' ? 'js' : 'html',
     'no-cache': true,
     'heading-depth': 2,
     plugin: '@godaddy/dmd'

--- a/src/helpers/jsdoc-utils/get-data.js
+++ b/src/helpers/jsdoc-utils/get-data.js
@@ -1,9 +1,13 @@
 const { spawnSync } = require('child_process')
 
-module.exports = ({ glob, jsdoc2md }, type) => {
+module.exports = ({ fs, glob, jsdoc2md }, type) => {
   const opts = {
-    files: glob.sync('**/*.js', { ignore: 'node_modules/**' }),
-    'example-lang': type === 'package' ? 'js' : 'html',
+    files: type === 'package'
+      ? glob.sync('**/*.js', { ignore: 'node_modules/**' })
+      : JSON.parse(fs.readFileSync('package.json', 'utf8')).main,
+    'example-lang': type === 'package'
+      ? 'js'
+      : 'html',
     'no-cache': true,
     'heading-depth': 2,
     plugin: '@godaddy/dmd'

--- a/src/helpers/jsdoc-utils/index.js
+++ b/src/helpers/jsdoc-utils/index.js
@@ -2,7 +2,7 @@ module.exports = (moduleDir, templatePath, type) => {
   const modules = loadModuleDeps(moduleDir)
   console.log('INFO: generating documentation from provided template and all JS files in repository...')
   const data = {
-    ...require('./get-data.js')(modules),
+    ...require('./get-data.js')(modules, type),
     ...require(`${moduleDir}/get-data.js`)(modules)
   }
   const docs = require('./build-docs.js')(modules, data, `${moduleDir}/${type}-partial.md`, templatePath)

--- a/src/helpers/jsdoc-utils/index.js
+++ b/src/helpers/jsdoc-utils/index.js
@@ -1,14 +1,9 @@
 module.exports = (moduleDir, templatePath, type) => {
   const modules = loadModuleDeps(moduleDir)
   console.log('INFO: generating documentation from provided template and all JS files in repository...')
-  let data = {
-    ...require('./get-data.js')(modules)
-  }
-  if (type === 'package') {
-    data = {
-      ...data,
-      ...require(`${moduleDir}/get-data.js`)(modules)
-    }
+  const data = {
+    ...require('./get-data.js')(modules),
+    ...require(`${moduleDir}/get-data.js`)(modules)
   }
   const docs = require('./build-docs.js')(modules, data, `${moduleDir}/${type}-partial.md`, templatePath)
   console.log('SUCCESS: documentation successfully generated!')

--- a/src/main-handlers/api/build-examples.js
+++ b/src/main-handlers/api/build-examples.js
@@ -64,7 +64,7 @@ function formatNamedData (heading, data = '') {
 }
 
 function formatBlock (type, block) {
-  return block.length > 0 ? `_${type}:_\n\n\`\`\`HTTP\n${block.trim()}\n\`\`\`\n\n` : ''
+  return `_${type}:_\n\n\`\`\`HTTP\n${block.trim()}\n\`\`\`\n\n`
 }
 
 function formatExample (example, heading) {

--- a/src/main-handlers/element/element-partial.md
+++ b/src/main-handlers/element/element-partial.md
@@ -1,3 +1,7 @@
+# Usage instructions
+
+{{>instructions}}
+
 # Custom element documentation
 
 {{>main}}

--- a/src/main-handlers/element/get-data.js
+++ b/src/main-handlers/element/get-data.js
@@ -14,7 +14,7 @@ module.exports = ({ fs }) => {
     : ''
   const paths = {
     masterPath: transformPath(path),
-    releasePath: transformPath(path, 'release/v1.0.0')
+    releasePath: transformPath(path, 'release/v1.0.0/')
   }
   return {
     instructions: `${getElementInstructions(path)}\n\n${getBrowserInstructions(paths)}`

--- a/src/main-handlers/element/get-data.js
+++ b/src/main-handlers/element/get-data.js
@@ -1,6 +1,12 @@
 module.exports = ({ fs }) => {
   const pjson = JSON.parse(fs.readFileSync('package.json', 'utf8'))
-  const uploadData = pjson?.kaskadi?.['s3-push']?.files
+  // TODO: below is my original approach for the code. This works only in Node 14+ and Node 14 will move to LTS on 27.10.2020 with Node 12 going to maintenance on 30.11.2020. This means we won't be using this syntax for now but may want to enable node14 in the action at some point in the future
+  // const uploadData = pjson?.kaskadi?.['s3-push']?.files
+  const uploadData = pjson.kaskadi
+    ? pjson.kaskadi['s3-push']
+      ? pjson.kaskadi['s3-push'].files
+      : undefined
+    : undefined
   const path = uploadData
     ? uploadData.filter(data => data.dest.includes(pjson.main))[0]
     : ''

--- a/src/main-handlers/element/get-data.js
+++ b/src/main-handlers/element/get-data.js
@@ -17,7 +17,7 @@ module.exports = ({ fs }) => {
     releasePath: transformPath(path, 'release/v1.0.0/')
   }
   return {
-    instructions: `${getElementInstructions(path)}\n\n${getBrowserInstructions(paths)}`
+    instructions: `${getElementInstructions(paths)}\n\n${getBrowserInstructions(paths)}`
   }
 }
 

--- a/src/main-handlers/element/get-data.js
+++ b/src/main-handlers/element/get-data.js
@@ -1,17 +1,19 @@
 module.exports = ({ fs }) => {
   const pjson = JSON.parse(fs.readFileSync('package.json', 'utf8'))
   // TODO: below is my original approach for the code. This works only in Node 14+ and Node 14 will move to LTS on 27.10.2020 with Node 12 going to maintenance on 30.11.2020. This means we won't be using this syntax for now but may want to enable node14 in the action at some point in the future
-  // const uploadData = pjson?.kaskadi?.['s3-push']?.files
-  const uploadData = pjson.kaskadi
+  // const files = pjson?.kaskadi?.['s3-push']?.files || []
+  const files = pjson.kaskadi
     ? pjson.kaskadi['s3-push']
-      ? pjson.kaskadi['s3-push'].files
-      : undefined
-    : undefined
-  const path = uploadData
-    ? uploadData
-      .filter(data => data.dest.includes(pjson.main))[0]
-      .dest
-    : ''
+      ? pjson.kaskadi['s3-push'].files || []
+      : []
+    : []
+  const matchingFiles = files.filter(file => file.dest.includes(pjson.main))
+  if (matchingFiles.length === 0) {
+    return {
+      instructions: 'Usage instructions unavailable: no published files were matching the _main_ file provided in [`package.json`](./package.json). You may want to have a look at the definition of `kaskadi.s3-push.files` custom field definition in [`package.json`](./package.json).'
+    }
+  }
+  const path = matchingFiles[0].dest
   const paths = {
     masterPath: transformPath(path),
     releasePath: transformPath(path, 'release/v1.0.0/')

--- a/src/main-handlers/element/get-data.js
+++ b/src/main-handlers/element/get-data.js
@@ -10,7 +10,7 @@ module.exports = ({ fs }) => {
   const matchingFiles = files.filter(file => file.dest.includes(pjson.main))
   if (matchingFiles.length === 0) {
     return {
-      instructions: 'Usage instructions unavailable: no published files were matching the _main_ file provided in [`package.json`](./package.json). You may want to have a look at the definition of `kaskadi.s3-push.files` custom field definition in [`package.json`](./package.json).'
+      instructions: '**Usage instructions unavailable:** none of the published files were matching the _main_ file provided in [`package.json`](./package.json). You may want to have a look at the definition of `kaskadi.s3-push.files` custom field definition in [`package.json`](./package.json).'
     }
   }
   const path = matchingFiles[0].dest

--- a/src/main-handlers/element/get-data.js
+++ b/src/main-handlers/element/get-data.js
@@ -8,7 +8,9 @@ module.exports = ({ fs }) => {
       : undefined
     : undefined
   const path = uploadData
-    ? uploadData.filter(data => data.dest.includes(pjson.main))[0]
+    ? uploadData
+      .filter(data => data.dest.includes(pjson.main))[0]
+      .dest
     : ''
   const paths = {
     masterPath: transformPath(path),

--- a/src/main-handlers/element/get-data.js
+++ b/src/main-handlers/element/get-data.js
@@ -1,0 +1,38 @@
+module.exports = ({ fs }) => {
+  const pjson = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+  const uploadData = pjson?.kaskadi?.['s3-push']?.files
+  const path = uploadData
+    ? uploadData.filter(data => data.dest.includes(pjson.main))[0]
+    : ''
+  const paths = {
+    masterPath: transformPath(path),
+    releasePath: transformPath(path, 'release/v1.0.0')
+  }
+  return {
+    instructions: `${getElementInstructions(path)}\n\n${getBrowserInstructions(paths)}`
+  }
+}
+
+function getElementInstructions ({ masterPath, releasePath }) {
+  return `In another element:
+\`\`\`js
+// using the latest version
+import '${masterPath}'
+// using a specific version (here v1)
+import '${releasePath}'
+\`\`\``
+}
+
+function getBrowserInstructions ({ masterPath, releasePath }) {
+  return `In the browser:
+\`\`\`html
+<!-- using the latest version -->
+<script type="module" src="${masterPath}"></script>
+<!-- using the latest version -->
+<script type="module" src="${releasePath}"></script>
+\`\`\``
+}
+
+function transformPath (path, releasePath = '') {
+  return `https://cdn.klimapartner.net/${path.replace('{branch}', releasePath)}`
+}

--- a/test/api/multi-endpoints/serverless.yml
+++ b/test/api/multi-endpoints/serverless.yml
@@ -32,6 +32,6 @@ provider:
     type: s3, sns, etc.
 functions:
   HelloWorld: ${file(./lambdas/hello-world/serverless.yml)}
-  Again: ${file(./lambdas/again/serverless.yml)}
   AgainHelloWorld: ${file(./lambdas/again-hello-world/serverless.yml)}
+  Again: ${file(./lambdas/again/serverless.yml)}
   HelloWorldAgain: ${file(./lambdas/hello-world-again/serverless.yml)}

--- a/test/api/multi-endpoints/validation.md
+++ b/test/api/multi-endpoints/validation.md
@@ -144,8 +144,8 @@ No examples found for this method.
 
 The following lambda functions are used in this API:
 - [hello-world](#hello-world)
-- [again](#again)
 - [again-hello-world](#again-hello-world)
+- [again](#again)
 - [hello-world-again](#hello-world-again)
 
 The following layers are used in this API:
@@ -159,19 +159,19 @@ _no layer defined in the [configuration file](./serverless.yml)._
 
 See [configuration file](./serverless.yml) for more details.
 
-## again <a name="again"></a>
-
-|  Name | Sources                      | Timeout |               Handler               |
-| :---: | :--------------------------- | :-----: | :---------------------------------: |
-| again | <ul><li>HTTP (GET)</li></ul> | default | [handler](./lambdas/again/index.js) |
-
-See [configuration file](./serverless.yml) for more details.
-
 ## again-hello-world <a name="again-hello-world"></a>
 
 |        Name       | Sources                      | Timeout |                     Handler                     |
 | :---------------: | :--------------------------- | :-----: | :---------------------------------------------: |
 | again-hello-world | <ul><li>HTTP (GET)</li></ul> | default | [handler](./lambdas/again-hello-world/index.js) |
+
+See [configuration file](./serverless.yml) for more details.
+
+## again <a name="again"></a>
+
+|  Name | Sources                      | Timeout |               Handler               |
+| :---: | :--------------------------- | :-----: | :---------------------------------: |
+| again | <ul><li>HTTP (GET)</li></ul> | default | [handler](./lambdas/again/index.js) |
 
 See [configuration file](./serverless.yml) for more details.
 

--- a/test/element/nested/elements/kaskadi-section.js
+++ b/test/element/nested/elements/kaskadi-section.js
@@ -1,0 +1,31 @@
+/* eslint-env browser, mocha */
+import { KaskadiElement, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
+
+/**
+ * Template element for the Kaskadi application
+ *
+ * @module kaskadi-section
+ *
+ * @param {string} lang - element's language
+ *
+ * @example
+ *
+ * <kaskadi-section lang="en">lorem ipsum but short</kaskadi-section>
+ */
+
+class KaskadiSection extends KaskadiElement {
+  static get properties () {
+    return {
+      lang: { type: String }
+    }
+  }
+
+  render () {
+    return html`
+      <p>Current language is ${this.lang}</p>
+      <slot></slot>
+    `
+  }
+}
+
+customElements.define('kaskadi-section', KaskadiSection)

--- a/test/element/nested/index.js
+++ b/test/element/nested/index.js
@@ -1,8 +1,0 @@
-/* eslint no-unused-vars: off */
-/**
- * A quite wonderful function.
- * @param {object} - Privacy gown
- * @param {object} - Security
- * @returns {survival}
- */
-function protection (cloak, dagger) {}

--- a/test/element/nested/kaskadi-custom-element.js
+++ b/test/element/nested/kaskadi-custom-element.js
@@ -1,0 +1,36 @@
+/* eslint-env browser, mocha */
+import { KaskadiElement, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
+
+import './elements/kaskadi-section.js'
+
+/**
+ * Template element for the Kaskadi application
+ *
+ * @module kaskadi-custom-element
+ *
+ * @param {string} lang - element's language
+ * @param {string} title - element's title
+ *
+ * @example
+ *
+ * <kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+ */
+
+class KaskadiCustomElement extends KaskadiElement {
+  static get properties () {
+    return {
+      lang: { type: String },
+      title: { type: String }
+    }
+  }
+
+  render () {
+    return html`
+      <h1>${this.title}</h1>
+      <p>Current language is ${this.lang}</p>
+      <kaskadi-section lang="${this.lang}">lorem ipsum but short</kaskadi-section>
+    `
+  }
+}
+
+customElements.define('kaskadi-custom-element', KaskadiCustomElement)

--- a/test/element/nested/modules/helper.js
+++ b/test/element/nested/modules/helper.js
@@ -1,8 +1,0 @@
-/* eslint no-unused-vars: off */
-/**
- * A function to call for help.
- * @param {string} - Message to send
- * @param {object} - Destination for message
- * @returns {call}
- */
-function help (message, destination) {}

--- a/test/element/nested/package.json
+++ b/test/element/nested/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "kaskadi-custom-element",
+  "version": "1.0.0",
+  "description": "",
+  "main": "kaskadi-custom-element.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaskadi/kaskadi-custom-element.git"
+  },
+  "keywords": [],
+  "author": "Klimapartner GmbH <kontakt@klimapartner.de> (https://klimapartner.de)",
+  "contributors": [
+    "Holger Will <h.will@klimapartner.de>",
+    "Alexis Lemaire <a.lemaire@klimapartner.de>"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kaskadi/kaskadi-custom-element/issues"
+  },
+  "homepage": "https://github.com/kaskadi/kaskadi-custom-element#readme",
+  "kaskadi": {
+    "s3-push": {
+      "files": [
+        {
+          "src": "kaskadi-custom-element.js",
+          "dest": "modules/@kaskadi/kaskadi-custom-element/{branch}kaskadi-custom-element.js"
+        },
+        {
+          "src": "example/index.html",
+          "dest": "modules/@kaskadi/kaskadi-custom-element/{branch}example/index.html"
+        }
+      ]
+    }
+  },
+  "dependencies": {}
+}

--- a/test/element/nested/validation.md
+++ b/test/element/nested/validation.md
@@ -1,37 +1,35 @@
+# Usage instructions
+
+In another element:
+```js
+// using the latest version
+import 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/kaskadi-custom-element.js'
+// using a specific version (here v1)
+import 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/release/v1.0.0/kaskadi-custom-element.js'
+```
+
+In the browser:
+```html
+<!-- using the latest version -->
+<script type="module" src="https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/kaskadi-custom-element.js"></script>
+<!-- using the latest version -->
+<script type="module" src="https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/release/v1.0.0/kaskadi-custom-element.js"></script>
+```
+
 # Custom element documentation
 
-## Functions
+## kaskadi-custom-element
 
-Name | Description
------- | -----------
-[protection(cloak, dagger)] | A quite wonderful function.
-[help(message, destination)] | A function to call for help.
+Template element for the Kaskadi application
 
-
-## protection(cloak, dagger)
-
-A quite wonderful function.
-
-**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| cloak | `object` | Privacy gown |
-| dagger | `object` | Security |
+| lang | `string` | element's language |
+| title | `string` | element's title |
 
-
-## help(message, destination)
-
-A function to call for help.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| message | `string` | Message to send |
-| destination | `object` | Destination for message |
-
+**Example**  
+```html
+<kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+```
 <!-- LINKS -->
-
-[protection(cloak, dagger)]:#protectioncloak-dagger
-[help(message, destination)]:#helpmessage-destination

--- a/test/element/no-template/index.js
+++ b/test/element/no-template/index.js
@@ -1,8 +1,0 @@
-/* eslint no-unused-vars: off */
-/**
- * A quite wonderful function.
- * @param {object} - Privacy gown
- * @param {object} - Security
- * @returns {survival}
- */
-function protection (cloak, dagger) {}

--- a/test/element/no-template/kaskadi-custom-element.js
+++ b/test/element/no-template/kaskadi-custom-element.js
@@ -1,0 +1,33 @@
+/* eslint-env browser, mocha */
+import { KaskadiElement, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
+
+/**
+ * Template element for the Kaskadi application
+ *
+ * @module kaskadi-custom-element
+ *
+ * @param {string} lang - element's language
+ * @param {string} title - element's title
+ *
+ * @example
+ *
+ * <kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+ */
+
+class KaskadiCustomElement extends KaskadiElement {
+  static get properties () {
+    return {
+      lang: { type: String },
+      title: { type: String }
+    }
+  }
+
+  render () {
+    return html`
+      <h1>${this.title}</h1>
+      <p>Current language is ${this.lang}</p>
+    `
+  }
+}
+
+customElements.define('kaskadi-custom-element', KaskadiCustomElement)

--- a/test/element/no-template/package.json
+++ b/test/element/no-template/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "kaskadi-custom-element",
+  "version": "1.0.0",
+  "description": "",
+  "main": "kaskadi-custom-element.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaskadi/kaskadi-custom-element.git"
+  },
+  "keywords": [],
+  "author": "Klimapartner GmbH <kontakt@klimapartner.de> (https://klimapartner.de)",
+  "contributors": [
+    "Holger Will <h.will@klimapartner.de>",
+    "Alexis Lemaire <a.lemaire@klimapartner.de>"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kaskadi/kaskadi-custom-element/issues"
+  },
+  "homepage": "https://github.com/kaskadi/kaskadi-custom-element#readme",
+  "kaskadi": {
+    "s3-push": {
+      "files": [
+        {
+          "src": "kaskadi-custom-element.js",
+          "dest": "modules/@kaskadi/kaskadi-custom-element/{branch}kaskadi-custom-element.js"
+        },
+        {
+          "src": "example/index.html",
+          "dest": "modules/@kaskadi/kaskadi-custom-element/{branch}example/index.html"
+        }
+      ]
+    }
+  },
+  "dependencies": {}
+}

--- a/test/element/no-template/validation.md
+++ b/test/element/no-template/validation.md
@@ -1,14 +1,35 @@
+# Usage instructions
+
+In another element:
+```js
+// using the latest version
+import 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/kaskadi-custom-element.js'
+// using a specific version (here v1)
+import 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/release/v1.0.0/kaskadi-custom-element.js'
+```
+
+In the browser:
+```html
+<!-- using the latest version -->
+<script type="module" src="https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/kaskadi-custom-element.js"></script>
+<!-- using the latest version -->
+<script type="module" src="https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/release/v1.0.0/kaskadi-custom-element.js"></script>
+```
+
 # Custom element documentation
 
-## protection(cloak, dagger)
+## kaskadi-custom-element
 
-A quite wonderful function.
+Template element for the Kaskadi application
 
-**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| cloak | `object` | Privacy gown |
-| dagger | `object` | Security |
+| lang | `string` | element's language |
+| title | `string` | element's title |
 
+**Example**  
+```html
+<kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+```
 <!-- LINKS -->

--- a/test/element/tests.js
+++ b/test/element/tests.js
@@ -32,6 +32,20 @@ describe('element docs generation', function () {
         delete process.env.INPUT_TEMPLATE
       })
   })
+  describe('usage instructions printing', function () {
+    it('should handle absence of match with main file', async () => {
+      await test(cwd, 'test/element/usage/no-match', 'validation.md')
+    })
+    it('should handle absence of files in kaskadi.s3-push inside of package.json', async () => {
+      await test(cwd, 'test/element/usage/no-files', 'validation.md')
+    })
+    it('should handle absence of s3-push in kaskadi inside of package.json', async () => {
+      await test(cwd, 'test/element/usage/no-s3-push', 'validation.md')
+    })
+    it('should handle absence of kaskadi field inside of package.json', async () => {
+      await test(cwd, 'test/element/usage/no-kaskadi', 'validation.md')
+    })
+  })
   after(() => {
     delete process.env.INPUT_TYPE
   })

--- a/test/element/usage/no-files/kaskadi-custom-element.js
+++ b/test/element/usage/no-files/kaskadi-custom-element.js
@@ -1,0 +1,33 @@
+/* eslint-env browser, mocha */
+import { KaskadiElement, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
+
+/**
+ * Template element for the Kaskadi application
+ *
+ * @module kaskadi-custom-element
+ *
+ * @param {string} lang - element's language
+ * @param {string} title - element's title
+ *
+ * @example
+ *
+ * <kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+ */
+
+class KaskadiCustomElement extends KaskadiElement {
+  static get properties () {
+    return {
+      lang: { type: String },
+      title: { type: String }
+    }
+  }
+
+  render () {
+    return html`
+      <h1>${this.title}</h1>
+      <p>Current language is ${this.lang}</p>
+    `
+  }
+}
+
+customElements.define('kaskadi-custom-element', KaskadiCustomElement)

--- a/test/element/usage/no-files/package.json
+++ b/test/element/usage/no-files/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "kaskadi-custom-element",
+  "version": "1.0.0",
+  "description": "",
+  "main": "kaskadi-custom-element.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaskadi/kaskadi-custom-element.git"
+  },
+  "keywords": [],
+  "author": "Klimapartner GmbH <kontakt@klimapartner.de> (https://klimapartner.de)",
+  "contributors": [
+    "Holger Will <h.will@klimapartner.de>",
+    "Alexis Lemaire <a.lemaire@klimapartner.de>"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kaskadi/kaskadi-custom-element/issues"
+  },
+  "homepage": "https://github.com/kaskadi/kaskadi-custom-element#readme",
+  "kaskadi": {
+    "s3-push": {}
+  },
+  "dependencies": {}
+}

--- a/test/element/usage/no-files/validation.md
+++ b/test/element/usage/no-files/validation.md
@@ -1,0 +1,21 @@
+# Usage instructions
+
+**Usage instructions unavailable:** none of the published files were matching the _main_ file provided in [`package.json`](./package.json). You may want to have a look at the definition of `kaskadi.s3-push.files` custom field definition in [`package.json`](./package.json).
+
+# Custom element documentation
+
+## kaskadi-custom-element
+
+Template element for the Kaskadi application
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| lang | `string` | element's language |
+| title | `string` | element's title |
+
+**Example**  
+```html
+<kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+```
+<!-- LINKS -->

--- a/test/element/usage/no-kaskadi/kaskadi-custom-element.js
+++ b/test/element/usage/no-kaskadi/kaskadi-custom-element.js
@@ -1,0 +1,33 @@
+/* eslint-env browser, mocha */
+import { KaskadiElement, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
+
+/**
+ * Template element for the Kaskadi application
+ *
+ * @module kaskadi-custom-element
+ *
+ * @param {string} lang - element's language
+ * @param {string} title - element's title
+ *
+ * @example
+ *
+ * <kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+ */
+
+class KaskadiCustomElement extends KaskadiElement {
+  static get properties () {
+    return {
+      lang: { type: String },
+      title: { type: String }
+    }
+  }
+
+  render () {
+    return html`
+      <h1>${this.title}</h1>
+      <p>Current language is ${this.lang}</p>
+    `
+  }
+}
+
+customElements.define('kaskadi-custom-element', KaskadiCustomElement)

--- a/test/element/usage/no-kaskadi/package.json
+++ b/test/element/usage/no-kaskadi/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "kaskadi-custom-element",
+  "version": "1.0.0",
+  "description": "",
+  "main": "kaskadi-custom-element.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaskadi/kaskadi-custom-element.git"
+  },
+  "keywords": [],
+  "author": "Klimapartner GmbH <kontakt@klimapartner.de> (https://klimapartner.de)",
+  "contributors": [
+    "Holger Will <h.will@klimapartner.de>",
+    "Alexis Lemaire <a.lemaire@klimapartner.de>"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kaskadi/kaskadi-custom-element/issues"
+  },
+  "homepage": "https://github.com/kaskadi/kaskadi-custom-element#readme",
+  "dependencies": {}
+}

--- a/test/element/usage/no-kaskadi/validation.md
+++ b/test/element/usage/no-kaskadi/validation.md
@@ -1,0 +1,21 @@
+# Usage instructions
+
+**Usage instructions unavailable:** none of the published files were matching the _main_ file provided in [`package.json`](./package.json). You may want to have a look at the definition of `kaskadi.s3-push.files` custom field definition in [`package.json`](./package.json).
+
+# Custom element documentation
+
+## kaskadi-custom-element
+
+Template element for the Kaskadi application
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| lang | `string` | element's language |
+| title | `string` | element's title |
+
+**Example**  
+```html
+<kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+```
+<!-- LINKS -->

--- a/test/element/usage/no-match/kaskadi-custom-element.js
+++ b/test/element/usage/no-match/kaskadi-custom-element.js
@@ -1,0 +1,33 @@
+/* eslint-env browser, mocha */
+import { KaskadiElement, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
+
+/**
+ * Template element for the Kaskadi application
+ *
+ * @module kaskadi-custom-element
+ *
+ * @param {string} lang - element's language
+ * @param {string} title - element's title
+ *
+ * @example
+ *
+ * <kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+ */
+
+class KaskadiCustomElement extends KaskadiElement {
+  static get properties () {
+    return {
+      lang: { type: String },
+      title: { type: String }
+    }
+  }
+
+  render () {
+    return html`
+      <h1>${this.title}</h1>
+      <p>Current language is ${this.lang}</p>
+    `
+  }
+}
+
+customElements.define('kaskadi-custom-element', KaskadiCustomElement)

--- a/test/element/usage/no-match/package.json
+++ b/test/element/usage/no-match/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "kaskadi-custom-element",
+  "version": "1.0.0",
+  "description": "",
+  "main": "kaskadi-custom-element.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaskadi/kaskadi-custom-element.git"
+  },
+  "keywords": [],
+  "author": "Klimapartner GmbH <kontakt@klimapartner.de> (https://klimapartner.de)",
+  "contributors": [
+    "Holger Will <h.will@klimapartner.de>",
+    "Alexis Lemaire <a.lemaire@klimapartner.de>"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kaskadi/kaskadi-custom-element/issues"
+  },
+  "homepage": "https://github.com/kaskadi/kaskadi-custom-element#readme",
+  "kaskadi": {
+    "s3-push": {
+      "files": [
+        {
+          "src": "kaskadi-custom-element.js",
+          "dest": "modules/@kaskadi/kaskadi-custom-element/{branch}kaskadi-wrong-element.js"
+        },
+        {
+          "src": "example/index.html",
+          "dest": "modules/@kaskadi/kaskadi-custom-element/{branch}example/index.html"
+        }
+      ]
+    }
+  },
+  "dependencies": {}
+}

--- a/test/element/usage/no-match/validation.md
+++ b/test/element/usage/no-match/validation.md
@@ -1,0 +1,21 @@
+# Usage instructions
+
+**Usage instructions unavailable:** none of the published files were matching the _main_ file provided in [`package.json`](./package.json). You may want to have a look at the definition of `kaskadi.s3-push.files` custom field definition in [`package.json`](./package.json).
+
+# Custom element documentation
+
+## kaskadi-custom-element
+
+Template element for the Kaskadi application
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| lang | `string` | element's language |
+| title | `string` | element's title |
+
+**Example**  
+```html
+<kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+```
+<!-- LINKS -->

--- a/test/element/usage/no-s3-push/kaskadi-custom-element.js
+++ b/test/element/usage/no-s3-push/kaskadi-custom-element.js
@@ -1,0 +1,33 @@
+/* eslint-env browser, mocha */
+import { KaskadiElement, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
+
+/**
+ * Template element for the Kaskadi application
+ *
+ * @module kaskadi-custom-element
+ *
+ * @param {string} lang - element's language
+ * @param {string} title - element's title
+ *
+ * @example
+ *
+ * <kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+ */
+
+class KaskadiCustomElement extends KaskadiElement {
+  static get properties () {
+    return {
+      lang: { type: String },
+      title: { type: String }
+    }
+  }
+
+  render () {
+    return html`
+      <h1>${this.title}</h1>
+      <p>Current language is ${this.lang}</p>
+    `
+  }
+}
+
+customElements.define('kaskadi-custom-element', KaskadiCustomElement)

--- a/test/element/usage/no-s3-push/package.json
+++ b/test/element/usage/no-s3-push/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "kaskadi-custom-element",
+  "version": "1.0.0",
+  "description": "",
+  "main": "kaskadi-custom-element.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaskadi/kaskadi-custom-element.git"
+  },
+  "keywords": [],
+  "author": "Klimapartner GmbH <kontakt@klimapartner.de> (https://klimapartner.de)",
+  "contributors": [
+    "Holger Will <h.will@klimapartner.de>",
+    "Alexis Lemaire <a.lemaire@klimapartner.de>"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kaskadi/kaskadi-custom-element/issues"
+  },
+  "homepage": "https://github.com/kaskadi/kaskadi-custom-element#readme",
+  "kaskadi": {},
+  "dependencies": {}
+}

--- a/test/element/usage/no-s3-push/validation.md
+++ b/test/element/usage/no-s3-push/validation.md
@@ -1,0 +1,21 @@
+# Usage instructions
+
+**Usage instructions unavailable:** none of the published files were matching the _main_ file provided in [`package.json`](./package.json). You may want to have a look at the definition of `kaskadi.s3-push.files` custom field definition in [`package.json`](./package.json).
+
+# Custom element documentation
+
+## kaskadi-custom-element
+
+Template element for the Kaskadi application
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| lang | `string` | element's language |
+| title | `string` | element's title |
+
+**Example**  
+```html
+<kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+```
+<!-- LINKS -->

--- a/test/element/with-template/index.js
+++ b/test/element/with-template/index.js
@@ -1,8 +1,0 @@
-/* eslint no-unused-vars: off */
-/**
- * A quite wonderful function.
- * @param {object} - Privacy gown
- * @param {object} - Security
- * @returns {survival}
- */
-function protection (cloak, dagger) {}

--- a/test/element/with-template/kaskadi-custom-element.js
+++ b/test/element/with-template/kaskadi-custom-element.js
@@ -1,0 +1,33 @@
+/* eslint-env browser, mocha */
+import { KaskadiElement, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
+
+/**
+ * Template element for the Kaskadi application
+ *
+ * @module kaskadi-custom-element
+ *
+ * @param {string} lang - element's language
+ * @param {string} title - element's title
+ *
+ * @example
+ *
+ * <kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+ */
+
+class KaskadiCustomElement extends KaskadiElement {
+  static get properties () {
+    return {
+      lang: { type: String },
+      title: { type: String }
+    }
+  }
+
+  render () {
+    return html`
+      <h1>${this.title}</h1>
+      <p>Current language is ${this.lang}</p>
+    `
+  }
+}
+
+customElements.define('kaskadi-custom-element', KaskadiCustomElement)

--- a/test/element/with-template/package.json
+++ b/test/element/with-template/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "kaskadi-custom-element",
+  "version": "1.0.0",
+  "description": "",
+  "main": "kaskadi-custom-element.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaskadi/kaskadi-custom-element.git"
+  },
+  "keywords": [],
+  "author": "Klimapartner GmbH <kontakt@klimapartner.de> (https://klimapartner.de)",
+  "contributors": [
+    "Holger Will <h.will@klimapartner.de>",
+    "Alexis Lemaire <a.lemaire@klimapartner.de>"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kaskadi/kaskadi-custom-element/issues"
+  },
+  "homepage": "https://github.com/kaskadi/kaskadi-custom-element#readme",
+  "kaskadi": {
+    "s3-push": {
+      "files": [
+        {
+          "src": "kaskadi-custom-element.js",
+          "dest": "modules/@kaskadi/kaskadi-custom-element/{branch}kaskadi-custom-element.js"
+        },
+        {
+          "src": "example/index.html",
+          "dest": "modules/@kaskadi/kaskadi-custom-element/{branch}example/index.html"
+        }
+      ]
+    }
+  },
+  "dependencies": {}
+}

--- a/test/element/with-template/validation.md
+++ b/test/element/with-template/validation.md
@@ -40,19 +40,40 @@ Publishing to CDN is done automatically via a `publish` workflow (see [here](./.
 ****
 
 <!-- automatically generated documentation will be placed in here -->
+# Usage instructions
+
+In another element:
+```js
+// using the latest version
+import 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/kaskadi-custom-element.js'
+// using a specific version (here v1)
+import 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/release/v1.0.0/kaskadi-custom-element.js'
+```
+
+In the browser:
+```html
+<!-- using the latest version -->
+<script type="module" src="https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/kaskadi-custom-element.js"></script>
+<!-- using the latest version -->
+<script type="module" src="https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/release/v1.0.0/kaskadi-custom-element.js"></script>
+```
+
 # Custom element documentation
 
-## protection(cloak, dagger)
+## kaskadi-custom-element
 
-A quite wonderful function.
+Template element for the Kaskadi application
 
-**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| cloak | `object` | Privacy gown |
-| dagger | `object` | Security |
+| lang | `string` | element's language |
+| title | `string` | element's title |
 
+**Example**  
+```html
+<kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+```
 <!-- LINKS -->
 <!-- automatically generated documentation will be placed in here -->
 

--- a/test/element/wrong-template/index.js
+++ b/test/element/wrong-template/index.js
@@ -1,8 +1,0 @@
-/* eslint no-unused-vars: off */
-/**
- * A quite wonderful function.
- * @param {object} - Privacy gown
- * @param {object} - Security
- * @returns {survival}
- */
-function protection (cloak, dagger) {}

--- a/test/element/wrong-template/kaskadi-custom-element.js
+++ b/test/element/wrong-template/kaskadi-custom-element.js
@@ -1,0 +1,33 @@
+/* eslint-env browser, mocha */
+import { KaskadiElement, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
+
+/**
+ * Template element for the Kaskadi application
+ *
+ * @module kaskadi-custom-element
+ *
+ * @param {string} lang - element's language
+ * @param {string} title - element's title
+ *
+ * @example
+ *
+ * <kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+ */
+
+class KaskadiCustomElement extends KaskadiElement {
+  static get properties () {
+    return {
+      lang: { type: String },
+      title: { type: String }
+    }
+  }
+
+  render () {
+    return html`
+      <h1>${this.title}</h1>
+      <p>Current language is ${this.lang}</p>
+    `
+  }
+}
+
+customElements.define('kaskadi-custom-element', KaskadiCustomElement)

--- a/test/element/wrong-template/package.json
+++ b/test/element/wrong-template/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "kaskadi-custom-element",
+  "version": "1.0.0",
+  "description": "",
+  "main": "kaskadi-custom-element.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaskadi/kaskadi-custom-element.git"
+  },
+  "keywords": [],
+  "author": "Klimapartner GmbH <kontakt@klimapartner.de> (https://klimapartner.de)",
+  "contributors": [
+    "Holger Will <h.will@klimapartner.de>",
+    "Alexis Lemaire <a.lemaire@klimapartner.de>"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kaskadi/kaskadi-custom-element/issues"
+  },
+  "homepage": "https://github.com/kaskadi/kaskadi-custom-element#readme",
+  "kaskadi": {
+    "s3-push": {
+      "files": [
+        {
+          "src": "kaskadi-custom-element.js",
+          "dest": "modules/@kaskadi/kaskadi-custom-element/{branch}kaskadi-custom-element.js"
+        },
+        {
+          "src": "example/index.html",
+          "dest": "modules/@kaskadi/kaskadi-custom-element/{branch}example/index.html"
+        }
+      ]
+    }
+  },
+  "dependencies": {}
+}

--- a/test/element/wrong-template/validation.md
+++ b/test/element/wrong-template/validation.md
@@ -1,14 +1,35 @@
+# Usage instructions
+
+In another element:
+```js
+// using the latest version
+import 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/kaskadi-custom-element.js'
+// using a specific version (here v1)
+import 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/release/v1.0.0/kaskadi-custom-element.js'
+```
+
+In the browser:
+```html
+<!-- using the latest version -->
+<script type="module" src="https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/kaskadi-custom-element.js"></script>
+<!-- using the latest version -->
+<script type="module" src="https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-custom-element/release/v1.0.0/kaskadi-custom-element.js"></script>
+```
+
 # Custom element documentation
 
-## protection(cloak, dagger)
+## kaskadi-custom-element
 
-A quite wonderful function.
+Template element for the Kaskadi application
 
-**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| cloak | `object` | Privacy gown |
-| dagger | `object` | Security |
+| lang | `string` | element's language |
+| title | `string` | element's title |
 
+**Example**  
+```html
+<kaskadi-custom-element title="Welcome!" lang="en"></kaskadi-custom-element>
+```
 <!-- LINKS -->


### PR DESCRIPTION
**Changes description**
Extended element documentation generation logic to handle printing of usage instructions and also limit itself to the element itself (no nesting)

**New features**
- _instructions printing:_ now printing out instructions for usage of this element inside of another element and in the browser. This is extracted via the custom field `kaskadi.s3-push.files` and `main` inside of `package.json`.

**Updated features**
- _element documentation generation:_ now only reads the main file (found in `package.json` in `main` field) instead of checking all `.js` files. Will also output examples with `html` code highlighting (was `js`)
- _tests:_ updated tests accordingly + increased code coverage