### PR TITLE
Improved CSS custom properties retrieval

### DIFF
--- a/src/helpers/jsdoc-utils/index.js
+++ b/src/helpers/jsdoc-utils/index.js
@@ -1,5 +1,5 @@
 module.exports = (moduleDir, templatePath, type) => {
-  const modules = loadModuleDeps(moduleDir)
+  const modules = loadModuleDeps(moduleDir, type)
   console.log('INFO: generating documentation from provided template and all JS files in repository...')
   const data = {
     ...require('./get-data.js')(modules, type),
@@ -10,12 +10,13 @@ module.exports = (moduleDir, templatePath, type) => {
   modules.fs.writeFileSync('README.md', docs, 'utf8')
 }
 
-function loadModuleDeps (moduleDir) {
+function loadModuleDeps (moduleDir, type) {
   const modules = {
     fs: require('fs'),
     replaceInFile: require('../replace-in-file.js'),
     glob: require(`${moduleDir}/node_modules/glob`),
-    jsdoc2md: require(`${moduleDir}/node_modules/jsdoc-to-markdown`)
+    jsdoc2md: require(`${moduleDir}/node_modules/jsdoc-to-markdown`),
+    ...(type === 'element' && { table: require(`${moduleDir}/node_modules/markdown-table`) })
   }
   return modules
 }

--- a/src/helpers/jsdoc-utils/index.js
+++ b/src/helpers/jsdoc-utils/index.js
@@ -1,6 +1,6 @@
 module.exports = (moduleDir, templatePath, type) => {
   const modules = loadModuleDeps(moduleDir, type)
-  console.log('INFO: generating documentation from provided template and all JS files in repository...')
+  console.log('INFO: generating documentation from provided template and appropriated JS files in repository...')
   const data = {
     ...require('./get-data.js')(modules, type),
     ...require(`${moduleDir}/get-data.js`)(modules)

--- a/src/main-handlers/element/get-data.js
+++ b/src/main-handlers/element/get-data.js
@@ -1,4 +1,4 @@
-module.exports = ({ fs }) => {
+module.exports = (modules) => {
   const { main, kaskadi } = require(`${process.cwd()}/package.json`)
   // TODO: below is my original approach for the code. This works only in Node 14+ and Node 14 will move to LTS on 27.10.2020 with Node 12 going to maintenance on 30.11.2020. This means we won't be using this syntax for now but may want to enable node14 in the action at some point in the future
   // const files = kaskadi?.['s3-push']?.files || []
@@ -9,7 +9,7 @@ module.exports = ({ fs }) => {
     : []
   const matchingFiles = files.filter(file => file.dest.includes(main))
   const baseData = {
-    'custom-styles': require('./get-styles.js')(fs, main)
+    'custom-styles': require('./get-styles.js')(modules, main)
   }
   if (matchingFiles.length === 0) {
     return {

--- a/src/main-handlers/element/get-styles.js
+++ b/src/main-handlers/element/get-styles.js
@@ -13,10 +13,10 @@ function getCustomVars (fs, main) {
 }
 
 function findCustomVars (elem) {
-  const customVarsRegex = new RegExp(/(--.[^:,)]+)(?:(:)(.[^;)]+))?/, 'g')
+  const customVarsRegex = new RegExp(/(--.[^:,)]+)(?:(:)(.[^;\n]+))?/, 'g')
   // Regexp explanation:
   // - (--.[^:,)]+): have a capture group which matches a custom property (-- followed by any characters except colon and comma)
-  // - (?:(:)(.[^;)]+))?: we match up to 1 time a group consisting of a colon followed by anything which is not a semi-colon or a closing round bracket. The only part captured from this match is everything after the colon
+  // - (?:(:)(.[^;)\n]+))?: we match up to 1 time a group consisting of a colon followed by anything which is not a semi-colon or a line feed. The only part captured from this match is everything after the colon
   const matches = Array.from(elem.matchAll(customVarsRegex)) // we use here matchAll because we do a global match and unfortunately .match() doesn't return the individual capture groups. .matchAll() returns an iteratble, so we have to turn it into an Array
   return matches.map(match => {
     const name = match[1]

--- a/src/main-handlers/element/get-styles.js
+++ b/src/main-handlers/element/get-styles.js
@@ -1,8 +1,8 @@
-module.exports = (fs, main) => {
+module.exports = ({ fs, table }, main) => {
   if (!fs.existsSync(main)) {
     return `No file is matching the main file (\`${main}\`) provided in \`package.json\`...`
   }
-  return buildStylesDocs(getCustomVars(fs, main))
+  return buildStylesDocs(table, getCustomVars(fs, main))
 }
 
 function getCustomVars (fs, main) {
@@ -30,7 +30,6 @@ function findCustomVars (elem) {
 
 function filterCustomVars (customVars) {
   const uniqueVars = [...new Set(customVars.map(variable => variable.name))]
-  console.log(uniqueVars)
   return uniqueVars.map(variable => {
     const matchingVars = customVars.filter(customVariable => customVariable.name === variable)
     const matchingVarsWithDefault = matchingVars.filter(customVariable => customVariable.default)
@@ -38,10 +37,14 @@ function filterCustomVars (customVars) {
   })
 }
 
-function buildStylesDocs (cssVars) {
+function buildStylesDocs (table, cssVars) {
   if (cssVars.length === 0) {
     return 'No custom CSS properties found in this element.'
   }
-  const cssVarsList = cssVars.map(cssVar => `- \`${cssVar}\``).join('\n')
-  return `The following custom CSS properties are available for this element:\n\n${cssVarsList}`
+  const cssVarsTable = table([
+    ['CSS variable', 'Default'],
+    ...cssVars.map(variable => [variable.name, variable.default ? `\`${variable.default}\`` : ''])
+  ]
+  , { align: ['c', 'c'] })
+  return `The following custom CSS properties are available for this element:\n\n${cssVarsTable}`
 }

--- a/src/main-handlers/element/get-styles.js
+++ b/src/main-handlers/element/get-styles.js
@@ -8,10 +8,34 @@ module.exports = (fs, main) => {
 function getCustomVars (fs, main) {
   const { readFileSync } = fs
   const elem = readFileSync(main, 'utf8')
-  const customVarsRegex = new RegExp(/var\((.[^,]+),{1}.+\){1}/, 'g') // with this regexp we match var(...,...) and capture the first parameter (everything before comma, comma excluded => .[^,]+ )
+  const customVars = findCustomVars(elem)
+  return filterCustomVars(customVars)
+}
+
+function findCustomVars (elem) {
+  const customVarsRegex = new RegExp(/(--.[^:,)]+)(?:(:)(.[^;)]+))?/, 'g')
+  // Regexp explanation:
+  // - (--.[^:,)]+): have a capture group which matches a custom property (-- followed by any characters except colon and comma)
+  // - (?:(:)(.[^;)]+))?: we match up to 1 time a group consisting of a colon followed by anything which is not a semi-colon or a closing round bracket. The only part captured from this match is everything after the colon
   const matches = Array.from(elem.matchAll(customVarsRegex)) // we use here matchAll because we do a global match and unfortunately .match() doesn't return the individual capture groups. .matchAll() returns an iteratble, so we have to turn it into an Array
-  const customVars = matches.map(match => match[1].trim())
-  return [...new Set(customVars)]
+  return matches.map(match => {
+    const name = match[1]
+    const value = match[3]
+    return {
+      name: name.trim(),
+      ...(value && { default: value.trim() })
+    }
+  })
+}
+
+function filterCustomVars (customVars) {
+  const uniqueVars = [...new Set(customVars.map(variable => variable.name))]
+  console.log(uniqueVars)
+  return uniqueVars.map(variable => {
+    const matchingVars = customVars.filter(customVariable => customVariable.name === variable)
+    const matchingVarsWithDefault = matchingVars.filter(customVariable => customVariable.default)
+    return matchingVarsWithDefault.length > 0 ? matchingVarsWithDefault[0] : matchingVars[0] // we grab here only the first variable with default found (if there is one) because defining multiple default is bad practice
+  })
 }
 
 function buildStylesDocs (cssVars) {

--- a/src/main-handlers/element/get-styles.js
+++ b/src/main-handlers/element/get-styles.js
@@ -42,9 +42,9 @@ function buildStylesDocs (table, cssVars) {
     return 'No custom CSS properties found in this element.'
   }
   const cssVarsTable = table([
-    ['CSS variable', 'Default'],
+    ['CSS property name', 'Default'],
     ...cssVars.map(variable => [variable.name, variable.default ? `\`${variable.default}\`` : ''])
   ]
-  , { align: ['c', 'c'] })
+  , { align: ['l', 'c'] })
   return `The following custom CSS properties are available for this element:\n\n${cssVarsTable}`
 }

--- a/src/main-handlers/element/package-lock.json
+++ b/src/main-handlers/element/package-lock.json
@@ -430,6 +430,14 @@
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
       "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA=="
     },
+    "markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "requires": {
+        "repeat-string": "^1.0.0"
+      }
+    },
     "marked": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
@@ -554,6 +562,11 @@
           }
         }
       }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "requizzle": {
       "version": "0.2.3",

--- a/src/main-handlers/element/package.json
+++ b/src/main-handlers/element/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "glob": "^7.1.6",
-    "jsdoc-to-markdown": "^6.0.1"
+    "jsdoc-to-markdown": "^6.0.1",
+    "markdown-table": "^2.0.0"
   }
 }

--- a/test/element/custom-style/kaskadi-custom-element.js
+++ b/test/element/custom-style/kaskadi-custom-element.js
@@ -26,6 +26,7 @@ class KaskadiCustomElement extends KaskadiElement {
   static get styles () {
     return css`
       :host, svg{
+        --icon-size: 56px;
         width:var(--icon-size, 48px);
         height:var(--icon-size, 48px);
         display: inline-block;

--- a/test/element/custom-style/kaskadi-custom-element.js
+++ b/test/element/custom-style/kaskadi-custom-element.js
@@ -27,6 +27,7 @@ class KaskadiCustomElement extends KaskadiElement {
     return css`
       :host, svg{
         --icon-size: 56px;
+        --background-color: red
         width:var(--icon-size, 48px);
         height:var(--icon-size, 48px);
         display: inline-block;

--- a/test/element/custom-style/validation.md
+++ b/test/element/custom-style/validation.md
@@ -38,10 +38,12 @@ Template element for the Kaskadi application
 
 The following custom CSS properties are available for this element:
 
-- `--icon-size`
-- `--background-color`
-- `--outline-color`
-- `--head-color`
-- `--day-color`
-- `--month-color`
-- `--name-color`
+| CSS property name  | Default |
+| :----------------- | :-----: |
+| --icon-size        |  `56px` |
+| --background-color |         |
+| --outline-color    |         |
+| --head-color       |         |
+| --day-color        |         |
+| --month-color      |         |
+| --name-color       |         |

--- a/test/element/custom-style/validation.md
+++ b/test/element/custom-style/validation.md
@@ -41,7 +41,7 @@ The following custom CSS properties are available for this element:
 | CSS property name  | Default |
 | :----------------- | :-----: |
 | --icon-size        |  `56px` |
-| --background-color |         |
+| --background-color |  `red`  |
 | --outline-color    |         |
 | --head-color       |         |
 | --day-color        |         |


### PR DESCRIPTION
**Changes description**
Improved CSS custom properties retrieval by extending the search to patterns like `--some-var: value;` in order to retrieve custom CSS properties which may have a clear default (instead of one changing from selector to selector).

**Updated features**
- _CSS custom properties retrieval:_ now handling `--some-var: value;` syntax and printing the result as a table containing the property name and its default. We assume that the coding style would follow a clean practice (f.e. define all custom variables under `:host` and only use them in selectors via `var(--my-var)` or `calc(var(--my-var) ...)`. If the element style is designed as a repetition of `var(--my-var, default)` across multiple selectors then only the name of the variable will be retrieved (as the default may vary and would make the documentation hard to comprehend)