### PR TITLE
Limiting CSS custom properties retrieval to styles

### DIFF
--- a/src/main-handlers/element/get-styles.js
+++ b/src/main-handlers/element/get-styles.js
@@ -7,9 +7,27 @@ module.exports = ({ fs, table }, main) => {
 
 function getCustomVars (fs, main) {
   const { readFileSync } = fs
-  const elem = readFileSync(main, 'utf8')
-  const customVars = findCustomVars(elem)
+  const styles = getStyles(readFileSync(main, 'utf8'))
+  const customVars = findCustomVars(styles)
   return filterCustomVars(customVars)
+}
+
+function getStyles (file) {
+  // this function extracts from the file the lines which are dedicated to styling only
+  const fileLines = file.split('\n')
+  const getLines = (fileLines, startToken, endToken) => {
+    const start = fileLines.findIndex(line => line.includes(startToken))
+    let startIndent = 0
+    for (const char of fileLines[start].split('')) {
+      if (char !== ' ') break
+      startIndent++
+    }
+    const end = fileLines.slice(start, -1).findIndex(line => line.startsWith(endToken, startIndent)) + start
+    return { start, end }
+  }
+  const staticLines = getLines(fileLines, 'static get styles', '}')
+  const dynamicLines = getLines(fileLines, '<style>', '</style>')
+  return [...fileLines.slice(staticLines.start, staticLines.end + 1), ...fileLines.slice(dynamicLines.start, dynamicLines.end + 1)].join('\n')
 }
 
 function findCustomVars (elem) {

--- a/test/element/custom-style/kaskadi-custom-element.js
+++ b/test/element/custom-style/kaskadi-custom-element.js
@@ -44,6 +44,11 @@ class KaskadiCustomElement extends KaskadiElement {
 
   render () {
     return html`
+      <style>
+        :host {
+          --outline-color: red;
+        }
+      </style>
       <h1>${this.title}</h1>
       <p>Current language is ${this.lang}</p>
     `

--- a/test/element/custom-style/validation.md
+++ b/test/element/custom-style/validation.md
@@ -42,7 +42,7 @@ The following custom CSS properties are available for this element:
 | :----------------- | :-----: |
 | --icon-size        |  `56px` |
 | --background-color |  `red`  |
-| --outline-color    |         |
+| --outline-color    |  `red`  |
 | --head-color       |         |
 | --day-color        |         |
 | --month-color      |         |


### PR DESCRIPTION
**Changes description**
CSS custom properties retrieval now only reads the styling related lines of code in the element's source code. This avoids finding similar to CSS properties patterns (starting with `--`) somewhere else in the code like for example in an HTML example in a JSDoc comment

**Updated features**
- _CSS custom properties retrieval logic:_ now it first extracts from the source code the portions of code related to static and dynamic styles. It then reads those specific portions to find any custom CSS properties
- _tests:_ updated tests to cover dynamic styles custom properties retrieval